### PR TITLE
UUID and Optimization Fixes

### DIFF
--- a/git/git.go
+++ b/git/git.go
@@ -44,7 +44,7 @@ func formatGitURL(url, branch string) string {
 	return ""
 }
 
-func RemoteShaChanged(url, branch, sha string) bool {
+func RemoteShaChanged(url, branch, sha, uuid string) bool {
 	formattedURL := formatGitURL(url, branch)
 
 	if formattedURL == "" {
@@ -55,13 +55,14 @@ func RemoteShaChanged(url, branch, sha string) bool {
 		CheckRedirect: func(req *http.Request, via []*http.Request) error {
 			req.Header.Set("Accept", "application/vnd.github.chitauri-preview+sha")
 			req.Header.Set("If-None-Match", fmt.Sprintf("\"%s\"", sha))
-
+			req.Header.Set("X-Install-UUID", uuid)
 			return nil
 		},
 	}
 	req, _ := http.NewRequest("GET", formattedURL, nil)
 	req.Header.Set("Accept", "application/vnd.github.chitauri-preview+sha")
 	req.Header.Set("If-None-Match", fmt.Sprintf("\"%s\"", sha))
+	req.Header.Set("X-Install-UUID", uuid)
 	res, _ := client.Do(req)
 
 	if res.StatusCode == 304 {

--- a/git/git.go
+++ b/git/git.go
@@ -58,14 +58,14 @@ func RemoteShaChanged(url, branch, sha, uuid string) bool {
 	client := &http.Client{
 		CheckRedirect: func(req *http.Request, via []*http.Request) error {
 			req.Header.Set("Accept", "application/vnd.github.chitauri-preview+sha")
-			req.Header.Set("If-None-Match", fmt.Sprintf("\"%s\"", sha))
+			req.Header.Set("If-None-Match", sha)
 			req.Header.Set("X-Install-UUID", uuid)
 			return nil
 		},
 	}
 	req, _ := http.NewRequest("GET", formattedURL, nil)
 	req.Header.Set("Accept", "application/vnd.github.chitauri-preview+sha")
-	req.Header.Set("If-None-Match", fmt.Sprintf("\"%s\"", sha))
+	req.Header.Set("If-None-Match", sha)
 	req.Header.Set("X-Install-UUID", uuid)
 	res, _ := client.Do(req)
 

--- a/manager/config.go
+++ b/manager/config.go
@@ -3,8 +3,6 @@ package manager
 import (
 	"encoding/json"
 	"io/ioutil"
-	"net/url"
-	"strings"
 )
 
 type CatalogType int
@@ -33,15 +31,6 @@ func (m *Manager) readConfig() error {
 		return err
 	}
 
-	for catalogName, catalogConfig := range config["catalogs"] {
-		if u, err := url.Parse(catalogConfig.URL); err == nil {
-			if strings.Split(u.Host, ":")[0] == "git.rancher.io" {
-				u.Path = strings.Join([]string{strings.TrimRight(u.Path, "/"), m.uuid}, "/")
-				catalogConfig.URL = u.String()
-				config["catalogs"][catalogName] = catalogConfig
-			}
-		}
-	}
 	m.config = config["catalogs"]
 
 	return nil

--- a/manager/local.go
+++ b/manager/local.go
@@ -83,7 +83,7 @@ func (m *Manager) prepareGitRepoPath(catalog model.Catalog, update bool, catalog
 		}
 	} else {
 		if update {
-			if git.RemoteShaChanged(catalog.URL, catalog.Branch, catalog.Commit) {
+			if git.RemoteShaChanged(catalog.URL, catalog.Branch, catalog.Commit, m.uuid) {
 				if err = git.Update(repoPath, branch); err != nil {
 					// Ignore error unless running in strict mode
 					if m.strict {


### PR DESCRIPTION
* Send UUID to mirror endpoint as a HTTP header
* Accept either http or https scheme and preserve it in formatted URL
* Fix `If-None-Match` header to not add extra quoets