### PR TITLE
Support catalog fields in compose.yml

### DIFF
--- a/manager/traverse.go
+++ b/manager/traverse.go
@@ -191,29 +191,31 @@ func traverseGitFiles(repoPath string) ([]model.Template, []error, error) {
 					readme = file.Contents
 				}
 			}
+
+			var compose string
 			var rancherCompose string
 			var templateVersion string
 			for _, file := range version.Files {
-
-				if file.Name == "rancher-compose.yml" {
+				switch file.Name {
+				case "template-version.yml":
+					templateVersion = file.Contents
+				case "compose.yml":
+					compose = file.Contents
+				case "rancher-compose.yml":
 					rancherCompose = file.Contents
 				}
-
-				if file.Name == "template-version.yml" {
-					templateVersion = file.Contents
-				}
-
 			}
 			newVersion := version
-			if rancherCompose != "" || templateVersion != "" {
-
+			if templateVersion != "" || compose != "" || rancherCompose != "" {
 				var err error
-				if rancherCompose != "" {
-					newVersion, err = parse.CatalogInfoFromRancherCompose([]byte(rancherCompose))
-				}
-
 				if templateVersion != "" {
 					newVersion, err = parse.CatalogInfoFromTemplateVersion([]byte(templateVersion))
+				}
+				if compose != "" {
+					newVersion, err = parse.CatalogInfoFromCompose([]byte(compose))
+				}
+				if rancherCompose != "" {
+					newVersion, err = parse.CatalogInfoFromRancherCompose([]byte(rancherCompose))
 				}
 
 				if err != nil {

--- a/parse/compose.go
+++ b/parse/compose.go
@@ -8,7 +8,6 @@ import (
 )
 
 func TemplateInfo(contents []byte) (model.Template, error) {
-
 	var data map[string]interface{}
 	if err := yaml.Unmarshal([]byte(contents), &data); err != nil {
 		return model.Template{}, err
@@ -30,11 +29,9 @@ func TemplateInfo(contents []byte) (model.Template, error) {
 	}
 
 	return template, nil
-
 }
 
 func CatalogInfoFromTemplateVersion(contents []byte) (model.Version, error) {
-
 	var template model.Version
 	if err := yaml.Unmarshal(contents, &template); err != nil {
 		return model.Version{}, err
@@ -74,4 +71,9 @@ func CatalogInfoFromRancherCompose(contents []byte) (model.Version, error) {
 	}
 
 	return model.Version{}, nil
+}
+
+func CatalogInfoFromCompose(contents []byte) (model.Version, error) {
+	contents = []byte(extractCatalogBlock(string(contents)))
+	return CatalogInfoFromRancherCompose(contents)
 }

--- a/parse/extract.go
+++ b/parse/extract.go
@@ -1,0 +1,38 @@
+package parse
+
+import (
+	"strings"
+	"unicode"
+)
+
+func extractCatalogBlock(contents string) string {
+	var catalogBlock []string
+	inBlock := false
+	lines := strings.Split(contents, "\n")
+	for i, line := range lines {
+		if isCommentLine(line) {
+			continue
+		}
+
+		if strings.HasPrefix(line, "catalog:") || strings.HasPrefix(line, ".catalog:") {
+			inBlock = true
+		}
+
+		if inBlock {
+			if i == len(lines) - 1  {
+				catalogBlock = append(catalogBlock, line)
+				return strings.Join(catalogBlock, "\n")
+			}
+			if len(catalogBlock) > 1 && len(line) > 0 && !unicode.IsSpace(rune(line[0])) {
+				return strings.Join(catalogBlock, "\n")
+			}
+			catalogBlock = append(catalogBlock, line)
+		}
+	}
+	return ""
+}
+
+func isCommentLine(line string) bool {
+	line = strings.TrimLeft(line, " \t")
+	return len(line) > 0 && line[0] == '#'
+}

--- a/parse/extract_test.go
+++ b/parse/extract_test.go
@@ -1,0 +1,54 @@
+package parse
+
+import (
+	"testing"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestExtractCatalogBlock(t *testing.T) {
+	assert.Equal(t, extractCatalogBlock(string(`
+s1:
+  image: nginx
+.catalog:
+  questions:
+  - q1
+  - q2`)), string(`.catalog:
+  questions:
+  - q1
+  - q2`))
+
+	assert.Equal(t, extractCatalogBlock(string(`
+.catalog:
+  questions:
+  - q1
+  - q2
+s1:
+  image: nginx`)), string(`.catalog:
+  questions:
+  - q1
+  - q2`))
+
+	assert.Equal(t, extractCatalogBlock(string(`
+catalog:
+  questions:
+  - q1
+  - q2
+services:
+  s1:
+    image: nginx`)), string(`catalog:
+  questions:
+  - q1
+  - q2`))
+
+	assert.Equal(t, extractCatalogBlock(string(`
+services:
+  s1:
+    image: nginx
+catalog:
+  questions:
+  - q1
+  - q2`)), string(`catalog:
+  questions:
+  - q1
+  - q2`))
+}

--- a/service/utils.go
+++ b/service/utils.go
@@ -138,16 +138,23 @@ func versionResource(apiContext *api.ApiContext, catalogName string, template mo
 	}
 
 	var questions []model.Question
-	rancherCompose, rancherComposeExists := filesMap["rancher-compose.yml"]
 	templateVersion, templateVersionExists := filesMap["template-version.yml"]
-	if rancherComposeExists {
-		catalogInfo, err := parse.CatalogInfoFromRancherCompose([]byte(rancherCompose))
+	compose, composeExists := filesMap["compose.yml"]
+	rancherCompose, rancherComposeExists := filesMap["rancher-compose.yml"]
+	if templateVersionExists {
+		catalogInfo, err := parse.CatalogInfoFromTemplateVersion([]byte(templateVersion))
 		if err != nil {
 			return nil, err
 		}
 		questions = catalogInfo.Questions
-	} else if templateVersionExists {
-		catalogInfo, err := parse.CatalogInfoFromTemplateVersion([]byte(templateVersion))
+	} else if composeExists {
+		catalogInfo, err := parse.CatalogInfoFromCompose([]byte(compose))
+		if err != nil {
+			return nil, err
+		}
+		questions = catalogInfo.Questions
+	} else if rancherComposeExists {
+		catalogInfo, err := parse.CatalogInfoFromRancherCompose([]byte(rancherCompose))
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
Supports catalog fields (in particular, questions) to be placed in `compose.yml` rather than `template-version.yml`.