### PR TITLE
Fix error handling

### DIFF
--- a/Dockerfile.dapper
+++ b/Dockerfile.dapper
@@ -14,7 +14,7 @@ RUN pip install tox
 ENV GOLANG_ARCH_amd64=amd64 GOLANG_ARCH_arm=armv6l GOLANG_ARCH=GOLANG_ARCH_${ARCH} \
     GOPATH=/go PATH=/go/bin:/usr/local/go/bin:${PATH} SHELL=/bin/bash
 
-RUN wget -O - https://storage.googleapis.com/golang/go1.7.4.linux-${!GOLANG_ARCH}.tar.gz | tar -xzf - -C /usr/local && \
+RUN wget -O - https://storage.googleapis.com/golang/go1.8.3.linux-${!GOLANG_ARCH}.tar.gz | tar -xzf - -C /usr/local && \
     go get github.com/rancher/trash && go get github.com/golang/lint/golint
 
 ENV DOCKER_URL_amd64=https://get.docker.com/builds/Linux/x86_64/docker-1.10.3 \

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -173,20 +173,19 @@ func formatDSN(user, password, address, dbname, params string) string {
 	return mysqlConfig.FormatDSN()
 }
 
-func refresh(m *manager.Manager, update bool) {
-	if err := m.RefreshAll(update); err != nil {
-		log.Errorf("Failed to perform catalog refresh: %v", err)
-	}
-}
-
 func autoRefresh(m *manager.Manager, refreshInterval int) {
+	var r = func(m *manager.Manager, update bool) {
+		if err := m.RefreshAll(update); err != nil {
+			log.Errorf("Failed to perform catalog refresh: %v", err)
+		}
+	}
 	// Refresh once without trying to update sources in case internet access isn't available
-	refresh(m, false)
+	r(m, false)
 
-	refresh(m, true)
+	r(m, true)
 	// TODO: don't want to have refresh running twice at the same time
 	for range time.Tick(time.Duration(refreshInterval) * time.Second) {
 		log.Debugf("Performing automatic refresh of all catalogs (interval %d seconds)", refreshInterval)
-		go refresh(m, true)
+		go r(m, true)
 	}
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -176,7 +176,14 @@ func formatDSN(user, password, address, dbname, params string) string {
 func autoRefresh(m *manager.Manager, refreshInterval int) {
 	var r = func(m *manager.Manager, update bool) {
 		if err := m.RefreshAll(update); err != nil {
-			log.Errorf("Failed to perform catalog refresh: %v", err)
+			if re, ok := err.(*manager.RepoRefreshError); ok && len(re.Errors) > 1 {
+				log.Errorf("Multiple errors encountered performing catalog refresh")
+				for _, e := range re.Errors {
+					log.Error(e)
+				}
+			} else {
+				log.Errorf("Failed to perform catalog refresh: %v", err)
+			}
 		}
 	}
 	// Refresh once without trying to update sources in case internet access isn't available

--- a/git/git.go
+++ b/git/git.go
@@ -55,16 +55,7 @@ func RemoteShaChanged(url, branch, sha, uuid string) bool {
 		return true
 	}
 
-	client := &http.Client{
-		CheckRedirect: func(req *http.Request, via []*http.Request) error {
-			req.Header.Set("Accept", "application/vnd.github.chitauri-preview+sha")
-			req.Header.Set("If-None-Match", fmt.Sprintf("\"%s\"", sha))
-			if uuid != "" {
-				req.Header.Set("X-Install-Uuid", uuid)
-			}
-			return nil
-		},
-	}
+	client := &http.Client{}
 	req, err := http.NewRequest("GET", formattedURL, nil)
 	if err != nil {
 		return true

--- a/git/git.go
+++ b/git/git.go
@@ -2,8 +2,6 @@ package git
 
 import (
 	"fmt"
-	"net/http"
-	"net/url"
 	"os"
 	"os/exec"
 	"strings"
@@ -26,56 +24,6 @@ func HeadCommit(path string) (string, error) {
 	cmd := exec.Command("git", "-C", path, "rev-parse", "HEAD")
 	output, err := cmd.Output()
 	return strings.Trim(string(output), "\n"), err
-}
-
-func formatGitURL(endpoint, branch string) string {
-	formattedURL := ""
-	if u, err := url.Parse(endpoint); err == nil {
-		pathParts := strings.Split(u.Path, "/")
-		switch strings.Split(u.Host, ":")[0] {
-		case "github.com":
-			if len(pathParts) >= 3 {
-				org := pathParts[1]
-				repo := strings.TrimSuffix(pathParts[2], ".git")
-				formattedURL = fmt.Sprintf("https://api.github.com/repos/%s/%s/commits/%s", org, repo, branch)
-			}
-		case "git.rancher.io":
-			repo := strings.TrimSuffix(pathParts[1], ".git")
-			u.Path = fmt.Sprintf("/repos/%s/commits/%s", repo, branch)
-			formattedURL = u.String()
-		}
-	}
-	return formattedURL
-}
-
-func RemoteShaChanged(url, branch, sha, uuid string) bool {
-	formattedURL := formatGitURL(url, branch)
-
-	if formattedURL == "" {
-		return true
-	}
-
-	client := &http.Client{}
-	req, err := http.NewRequest("GET", formattedURL, nil)
-	if err != nil {
-		return true
-	}
-	req.Header.Set("Accept", "application/vnd.github.chitauri-preview+sha")
-	req.Header.Set("If-None-Match", fmt.Sprintf("\"%s\"", sha))
-	if uuid != "" {
-		req.Header.Set("X-Install-Uuid", uuid)
-	}
-	res, err := client.Do(req)
-	if err != nil {
-		return true
-	}
-	defer res.Body.Close()
-
-	if res.StatusCode == 304 {
-		return false
-	}
-
-	return true
 }
 
 func IsValid(url string) bool {

--- a/integration/core/test_api.py
+++ b/integration/core/test_api.py
@@ -121,8 +121,11 @@ def test_get_catalogs(client):
     url = 'http://localhost:8088/v1-catalog/catalogs'
     response = requests.get(url, headers=DEFAULT_HEADERS)
     assert response.status_code == 200
-    resp = response.json()['data'][0]
-    assert resp['name'] == 'orig'
+    catalogs = response.json()['data']
+    for c in catalogs:
+        if c['name'] == 'orig':
+            resp = c
+            break
     assert resp['url'] == 'https://github.com/rancher/test-catalog'
     assert resp['links']['self'] == 'http://localhost:8088/' + \
         'v1-catalog/catalogs/orig?projectId=' + DEFAULT_ENV

--- a/manager/local.go
+++ b/manager/local.go
@@ -5,10 +5,14 @@ import (
 	"encoding/hex"
 	"fmt"
 	"io"
+	"net/http"
+	"net/url"
 	"os"
 	"path"
+	"strings"
 
 	log "github.com/Sirupsen/logrus"
+	"github.com/pkg/errors"
 	"github.com/rancher/catalog-service/git"
 	"github.com/rancher/catalog-service/helm"
 	"github.com/rancher/catalog-service/model"
@@ -69,27 +73,27 @@ func (m *Manager) prepareGitRepoPath(catalog model.Catalog, update bool, catalog
 	repoPath := path.Join(m.cacheRoot, catalog.EnvironmentId, repoBranchHash)
 
 	if err := os.MkdirAll(repoPath, 0755); err != nil {
-		return "", "", catalogType, err
+		return "", "", catalogType, errors.Wrap(err, "mkdir failed")
 	}
 
 	empty, err := dirEmpty(repoPath)
 	if err != nil {
-		return "", "", catalogType, err
+		return "", "", catalogType, errors.Wrap(err, "Empty directory check failed")
 	}
 
 	if empty {
 		if err = git.Clone(repoPath, catalog.URL, branch); err != nil {
-			return "", "", catalogType, err
+			return "", "", catalogType, errors.Wrap(err, "Clone failed")
 		}
 	} else {
 		if update {
-			if git.RemoteShaChanged(catalog.URL, catalog.Branch, catalog.Commit, m.uuid) {
+			changed, err := m.remoteShaChanged(catalog.URL, catalog.Branch, catalog.Commit, m.uuid)
+			if err != nil {
+				return "", "", catalogType, errors.Wrap(err, "Remote commit check failed")
+			}
+			if changed {
 				if err = git.Update(repoPath, branch); err != nil {
-					// Ignore error unless running in strict mode
-					if m.strict {
-						return "", "", catalogType, err
-					}
-					log.Errorf("Failed to update existing repo cache: %v", err)
+					return "", "", catalogType, errors.Wrap(err, "Update failed")
 				}
 				log.Debugf("catalog-service: updated catalog '%v'", catalog.Name)
 			}
@@ -97,5 +101,62 @@ func (m *Manager) prepareGitRepoPath(catalog model.Catalog, update bool, catalog
 	}
 
 	commit, err := git.HeadCommit(repoPath)
+	if err != nil {
+		err = errors.Wrap(err, "Retrieving head commit failed")
+	}
 	return repoPath, commit, catalogType, err
+}
+
+func formatGitURL(endpoint, branch string) string {
+	formattedURL := ""
+	if u, err := url.Parse(endpoint); err == nil {
+		pathParts := strings.Split(u.Path, "/")
+		switch strings.Split(u.Host, ":")[0] {
+		case "github.com":
+			if len(pathParts) >= 3 {
+				org := pathParts[1]
+				repo := strings.TrimSuffix(pathParts[2], ".git")
+				formattedURL = fmt.Sprintf("https://api.github.com/repos/%s/%s/commits/%s", org, repo, branch)
+			}
+		case "git.rancher.io":
+			repo := strings.TrimSuffix(pathParts[1], ".git")
+			u.Path = fmt.Sprintf("/repos/%s/commits/%s", repo, branch)
+			formattedURL = u.String()
+		}
+	}
+	return formattedURL
+}
+
+func (m *Manager) remoteShaChanged(repoURL, branch, sha, uuid string) (bool, error) {
+	formattedURL := formatGitURL(repoURL, branch)
+
+	if formattedURL == "" {
+		return true, nil
+	}
+
+	req, err := http.NewRequest("GET", formattedURL, nil)
+	if err != nil {
+		log.Warnf("Problem creating request to check git remote sha of repo [%v]: %v", repoURL, err)
+		return true, nil
+	}
+	req.Header.Set("Accept", "application/vnd.github.chitauri-preview+sha")
+	req.Header.Set("If-None-Match", fmt.Sprintf("\"%s\"", sha))
+	if uuid != "" {
+		req.Header.Set("X-Install-Uuid", uuid)
+	}
+	res, err := m.httpClient.Do(req)
+	if err != nil {
+		// Return timeout errors so caller can decide whether or not to proceed with updating the repo
+		if uErr, ok := err.(*url.Error); ok && uErr.Timeout() {
+			return false, errors.Wrapf(uErr, "Repo [%v] is not accessible", repoURL)
+		}
+		return true, nil
+	}
+	defer res.Body.Close()
+
+	if res.StatusCode == 304 {
+		return false, nil
+	}
+
+	return true, nil
 }

--- a/manager/manager.go
+++ b/manager/manager.go
@@ -1,12 +1,13 @@
 package manager
 
 import (
-	"errors"
 	"fmt"
-	"strings"
+	"net/http"
+	"time"
 
 	log "github.com/Sirupsen/logrus"
 	"github.com/jinzhu/gorm"
+	"github.com/pkg/errors"
 	"github.com/rancher/catalog-service/model"
 )
 
@@ -23,15 +24,21 @@ type Manager struct {
 	strict     bool
 	db         *gorm.DB
 	uuid       string
+	httpClient http.Client
 }
 
 func NewManager(cacheRoot string, configFile string, strict bool, db *gorm.DB, uuid string) *Manager {
+	client := http.Client{
+		Timeout: time.Second * 10,
+	}
+
 	return &Manager{
 		cacheRoot:  cacheRoot,
 		configFile: configFile,
 		strict:     strict,
 		db:         db,
 		uuid:       uuid,
+		httpClient: client,
 	}
 }
 
@@ -49,6 +56,14 @@ func (m *Manager) Refresh(environmentId string, update bool) error {
 	return m.refreshEnvironmentCatalogs(environmentId, update)
 }
 
+type RepoRefreshError struct {
+	Errors []error
+}
+
+func (e *RepoRefreshError) Error() string {
+	return fmt.Sprintf("%v", e.Errors)
+}
+
 func (m *Manager) refreshConfigCatalogs(update bool) error {
 	if err := m.readConfig(); err != nil {
 		return err
@@ -57,7 +72,7 @@ func (m *Manager) refreshConfigCatalogs(update bool) error {
 		return err
 	}
 
-	var refreshErrors []string
+	var refreshErrors []error
 	for name, config := range m.config {
 		catalog := model.Catalog{
 			Name:          name,
@@ -71,11 +86,11 @@ func (m *Manager) refreshConfigCatalogs(update bool) error {
 			catalog = existingCatalog
 		}
 		if err := m.refreshCatalog(catalog, update); err != nil {
-			refreshErrors = append(refreshErrors, fmt.Sprintf("%s: %v", catalog.Name, err))
+			refreshErrors = append(refreshErrors, errors.Wrapf(err, "Catalog refresh failed for %v (%v)", catalog.Name, catalog.URL))
 		}
 	}
 	if len(refreshErrors) > 0 {
-		return errors.New(strings.Join(refreshErrors, "\n"))
+		return &RepoRefreshError{Errors: refreshErrors}
 	}
 	return nil
 }
@@ -86,14 +101,14 @@ func (m *Manager) refreshEnvironmentCatalogs(environmentId string, update bool) 
 		return err
 	}
 
-	var refreshErrors []string
+	var refreshErrors []error
 	for _, catalog := range catalogs {
 		if err := m.refreshCatalog(catalog, update); err != nil {
-			refreshErrors = append(refreshErrors, fmt.Sprintf("%s: %v", catalog.Name, err))
+			refreshErrors = append(refreshErrors, errors.Wrapf(err, "Catalog refresh failed for %v (%v)", catalog.Name, catalog.URL))
 		}
 	}
 	if len(refreshErrors) > 0 {
-		return errors.New(strings.Join(refreshErrors, "\n"))
+		return &RepoRefreshError{Errors: refreshErrors}
 	}
 	return nil
 }
@@ -110,15 +125,16 @@ func (m *Manager) refreshCatalog(catalog model.Catalog, update bool) error {
 		return nil
 	}
 
-	templates, errors, err := traverseFiles(repoPath, catalog.Kind, catalogType)
+	templates, errs, err := traverseFiles(repoPath, catalog.Kind, catalogType)
 	if err != nil {
-		return err
+		return errors.Wrap(err, "Repo traversal failed")
 	}
-	if len(errors) != 0 {
+
+	if len(errs) != 0 {
 		if m.strict {
-			return fmt.Errorf("%v", errors)
+			return fmt.Errorf("%v", errs)
 		}
-		log.Errorf("Errors while parsing repo: %v", errors)
+		log.Errorf("Errors while parsing repo: %v", errs)
 	}
 
 	log.Debugf("Updating catalog %s", catalog.Name)

--- a/service/template.go
+++ b/service/template.go
@@ -171,11 +171,11 @@ func getTemplate(w http.ResponseWriter, r *http.Request, envId string) (int, err
 
 func refreshTemplates(w http.ResponseWriter, r *http.Request, envId string) (int, error) {
 	if err := m.Refresh(envId, true); err != nil {
-		return http.StatusBadRequest, err
+		return http.StatusInternalServerError, err
 	}
 	if envId != "global" {
 		if err := m.Refresh("global", true); err != nil {
-			return http.StatusBadRequest, err
+			return http.StatusInternalServerError, err
 		}
 	}
 	w.WriteHeader(http.StatusNoContent)


### PR DESCRIPTION
Addresses https://github.com/rancher/rancher/issues/9669 (and then some)

I ended up revamping our error handling a bit.

The end result is:
1. Functionality change: calls to the `refresh` api will now return 500 if the update failed. Previously, it would always return 200.
2. There is a timeout of 10 seconds added to to attempting to check the remote hash of our git mirror and all github.com repos. Furthermore, if the request times out, we do not attempt to perform the git fetch, as that can take up to five minutes
3. Reused an http client instead of creating a new one everytime we want to check a remote hash
4. Upgrade got to 1.8 to get a fix to copy headers when the client receives a redirect. This allowed us to remove a custom redirect handler that was copying headers.
5. If an error is encountered when updating an existing catalog that prevents us from updating the local git repo *do not* perform a DB update of the catalogs/templates. Previous behavior was to go ahead an update the db entries again, even though the git fetch failed.
5. Improved the logging around errors encountered when doing an auto refresh.
You used to get:
```
time="2017-08-22T17:42:57Z" level=error msg="Failed to update existing repo cache: exit status 128" 
time="2017-08-22T17:43:10Z" level=error msg="Failed to update existing repo cache: exit status 128" 
time="2017-08-22T17:47:31Z" level=error msg="Failed to update existing repo cache: exit status 128" 
time="2017-08-22T17:47:44Z" level=error msg="Failed to update existing repo cache: exit status 128" 
```
you now get:
```
timeme="2017-08-23T16:34:34Z" level=error msg="Multiple errors encountered performing catalog refresh" 
time="2017-08-23T16:34:34Z" level=error msg="Catalog refresh failed for community (https://git.rancher.io/community-catalog.git): Remote commit check failed: Repo [https://git.rancher.io/community-catalog.git] is not accessible: Get https://git.rancher.io/repos/community-catalog/commits/master: net/http: request canceled while waiting for connection (Client.Timeout exceeded while awaiting headers)" 
time="2017-08-23T16:34:34Z" level=error msg="Catalog refresh failed for library (https://git.rancher.io/rancher-catalog.git): Remote commit check failed: Repo [https://git.rancher.io/rancher-catalog.git] is not accessible: Get https://git.rancher.io/repos/rancher-catalog/commits/v1.6-development: net/http: request canceled while waiting for connection (Client.Timeout exceeded while awaiting headers)" 
```