### PR TITLE
Fix build scripts

### DIFF
--- a/scripts/build
+++ b/scripts/build
@@ -7,4 +7,6 @@ cd $(dirname $0)/..
 
 mkdir -p bin
 [ "$(uname)" != "Darwin" ] && LINKFLAGS="-linkmode external -extldflags -static -s"
-go build -tags "$TAGS" -ldflags "-X github.com/rancher/catalog-service/cmd.VERSION=$VERSION $LINKFLAGS" -o bin/rancher-catalog-service
+go build -ldflags "-X github.com/rancher/catalog-service/cmd.VERSION=$VERSION $LINKFLAGS" -o bin/rancher-catalog-service-sqlite
+# Production binary needs to be fully static
+CGO_ENABLED=0 go build -tags "nosqlite" -ldflags "-X github.com/rancher/catalog-service/cmd.VERSION=$VERSION $LINKFLAGS" -o bin/rancher-catalog-service

--- a/scripts/package
+++ b/scripts/package
@@ -9,8 +9,9 @@ ARCH=${ARCH:?"ARCH not set"}
 SUFFIX=""
 [ "${ARCH}" != "amd64" ] && SUFFIX="_${ARCH}"
 
-mv bin/rancher-catalog-service{,-sqlite}
-TAGS=nosqlite CGO_ENABLED=0 ./scripts/build
+if [ ! -e bin/rancher-catalog-service ]; then
+    ./scripts/build
+fi
 
 mkdir -p dist/artifacts
 tar cvJf dist/artifacts/rancher-catalog-service${SUFFIX}.tar.xz -C ./bin .

--- a/scripts/test
+++ b/scripts/test
@@ -12,7 +12,7 @@ PACKAGES=". $(find -name '*.go' | xargs -I{} dirname {} |  cut -f2 -d/ | sort -u
 [ "${ARCH}" == "amd64" ] && RACE=-race
 go test ${RACE} -cover -tags=test ${PACKAGES}
 
-./bin/rancher-catalog-service --sqlite --config scripts/test-repo.json -p 8088 --track=false &
+./bin/rancher-catalog-service-sqlite --sqlite --config scripts/test-repo.json -p 8088 --track=false &
 trap "kill $!" exit
 cd integration
 tox -e flake8,py27

--- a/scripts/test-warm
+++ b/scripts/test-warm
@@ -5,7 +5,7 @@ cd $(dirname $0)/..
 
 git clone https://github.com/rancher/test-catalog.git /tmp/test-catalog
 
-./bin/rancher-catalog-service --sqlite --config scripts/test-setup.json --validate || true
+./bin/rancher-catalog-service-sqlite --config scripts/test-setup.json --validate || true
 
 cd /tmp/test-catalog
 


### PR DESCRIPTION
Scripts used to only build sqlite version of the binary in the build
script and then rename that file and call the build script again from
the package script to build a production-worthy static binary. This
behavior is confusing and doesn't work if you just want to call the
build script to get a static binary.

This change does two things:
1. Just build both versions of the binary in the build script with the
appropriate names
2. In the package script, if the bin dir doesn't exist, call the build
script. This lets you to just call `make package` directly to get a
tarball if you need to.